### PR TITLE
Resetting state pollution in `mock_router`

### DIFF
--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -45,6 +45,8 @@ def test_router_register_handler_fn_pass(mock_router):
 
     assert len(mock_router) == 1
 
+    mock_router.__init__()
+
 
 def test_router_register_handler_fail(mock_router):
     """Test `bottle_neck.routing.Router.register_handler` error handling.


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_router_register_handler_fn_pass` by resetting state pollution in `mock_router` by calling method `__init__`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_routing.py::test_router_register_handler_fn_pass`:

```
        def fn():
            pass
    
        mock_router.register_handler(fn, entrypoint='/', methods=('GET', ))
    
>       assert len(mock_router) == 1
E       assert 2 == 1
E        +  where 2 = len(Router object: total 2 routes)
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
