### PR TITLE
order dependent test fix

### DIFF
--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -8,7 +8,7 @@ import bottle_neck.routing as routing
 import bottle_neck.cbv as handler
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def mock_router():
     """pytest fixture for `bottle_neck.routing.Router` class
     """
@@ -16,7 +16,7 @@ def mock_router():
     return routing.Router()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def mock_handler():
     """Pytest fixture for `bottle_neck.handlers.BaseHandler` subclass.
     """
@@ -61,12 +61,18 @@ def test_router_register_handler_cbv_pass(mock_router, mock_handler):
 
     mock_router.register_handler(mock_handler, entrypoint='/api')
 
-    assert len(mock_router) == 2
+    assert len(mock_router) == 1
 
 
 def test_router_mount_pass(mock_router, mock_app):
     """Test `bottle_neck.routing.Router.mount` method.
     """
+    def fn():
+        pass
+
+    mock_router.register_handler(fn, entrypoint='/', methods=('GET', ))
+    assert len(mock_router) == 1
+
     init_mounts = len(mock_app.routes)
     mock_router.mount(mock_app)
 


### PR DESCRIPTION
### Problem:
Detect some order-dependent tests in test_routing.py

### Method:
install pytest flakefinder with:
```
pip install pytest-flakefinder
```
and run:
```
pytest --flake-finder
```
### Result: several tests failed within test_routing.py

### My proposal:
By changing the scope of fixture to make sure all tests are independent from each other.

### My result:
can pass all flakefinder run.